### PR TITLE
Remove git remote after rename

### DIFF
--- a/renameApp.sh
+++ b/renameApp.sh
@@ -3,3 +3,4 @@ find . ! -name '.DS_Store' ! -name 'renameApp.sh' ! -path '*.git*' ! -path '*Pod
 mv "DefaultApp.xcodeproj" "$1.xcodeproj"
 mv "DefaultApp.xcworkspace" "$1.xcworkspace"
 mv "macOS/Resources/DefaultApp.sdef" "macOS/Resources/$1.sdef"
+git remote rm origin


### PR DESCRIPTION
The git remote still points to "DefaultApp" after cloning. This change
removes the remote and its references from the local repository. This
will avoid accidental pushes to DefaultApp